### PR TITLE
Fire a "validated" event on a form submit button

### DIFF
--- a/src/main/javascript/jquery.alv.js
+++ b/src/main/javascript/jquery.alv.js
@@ -965,7 +965,9 @@ alv.validators = {
                 }
 
                 bodyElem.delegate('#' + firingElem.attr('id'), 'click', function () {
+                    var validateEvent = new Event('validated');
                     if (!formHasErrors(settings.formsToSubmit)) {
+                        firingElem.trigger('validated');
                         eval($(this).data(constants.origClickEvent));
                     } else {
                         if (!$(messageBoxId).length) {


### PR DESCRIPTION
Proposed solution to Issues #8 and #9. Would be nice to be able to specify the event name that gets triggered via the plugin. The Maven changes are not run, so the target directory has not been updated.
