### PR TITLE
Remove trailing page_item_separator

### DIFF
--- a/src/main/plsql/render.sql
+++ b/src/main/plsql/render.sql
@@ -54,7 +54,7 @@ begin
   end if;
 
   l_render_result.attribute_01 := l_validation;
-  l_render_result.attribute_02 := l_items_to_validate;
+  l_render_result.attribute_02 := regexp_replace(l_items_to_validate, lco_page_item_separator || '$', '');
   l_render_result.attribute_03 := l_triggering_event;
   l_render_result.attribute_04 := l_condition;
   l_render_result.attribute_05 := l_forms_to_validate;


### PR DESCRIPTION
Fixes nbuytaert1/apex-live-validation#12

I've tested this under Apex 4 and Apex 5 EA3, and it works without any other changed behavior. This removes the trailing comma from the page item list `l_items_to_validate`, which lets the plug in work with jQuery > 1.7.2